### PR TITLE
chore: disable pr event

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -17,9 +17,6 @@ on:
   # runs regularly on main
   schedule:
     - cron: '0 6 * * *' # 6 AM UTC everyday for default branch
-  # runs on PRs via repository_dispatch, DEPRECATED, will be removed after workflow_call takes over
-  repository_dispatch:
-    types: [ ocm_pr ]
   # runs on PRs via workflow_call directly from within open-component-model/ocm
   workflow_call:
     secrets:


### PR DESCRIPTION
disables the PR event trigger because we now trigger with a workflow call