### PR TITLE
fix: condition in workflow

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -39,7 +39,7 @@ on:
 env:
   REPO: ${{ inputs.repo != '' && inputs.repo || 'open-component-model/ocm'}}
   REF: main
-  REF_FROM_OTHER_WORKFLOW: ${{ inputs.ref != '' }}
+
 permissions:
   contents: write
 jobs:
@@ -214,7 +214,7 @@ jobs:
           docker container rm -v registry
       - name: push
         uses: github-actions-x/commit@v2.9
-        if: ${{ env.REF_FROM_OTHER_WORKFLOW == false && always()}} # push result also on failure
+        if: ${{ inputs.ref == '' && always()}} # push result also on failure
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           commit-message: 'add test report'
@@ -222,7 +222,7 @@ jobs:
           name: github-ation
           email: noreply@github.com
       - name: send test result as PR comment
-        if: ${{ env.REF_FROM_OTHER_WORKFLOW == false && github.event.client_payload }}
+        if: ${{ inputs.ref == '' && github.event.client_payload }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
@@ -236,7 +236,7 @@ jobs:
       - name: Post to a Slack channel
         id: slack
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
-        if: ${{ env.REF_FROM_OTHER_WORKFLOW == false && github.ref_name  == 'main' && github.event_name == 'schedule' && always()}}
+        if: ${{ inputs.ref == '' && github.ref_name  == 'main' && github.event_name == 'schedule' && always()}}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove the `REF_FROM_OTHER_WORKFLOW` env var and inline the condition as `inputs.ref == ''`
- The env var stored a boolean expression result as a string (`"false"`), which failed the `== false` (boolean) comparison in step conditions due to GitHub Actions type coercion
- This caused the `push`, `PR comment`, and `Slack notification` steps to be silently skipped on every scheduled run

## Context
https://github.com/open-component-model/ocm-integrationtest/actions/runs/24021713282
