### PR TITLE
chore(GHA): remove push to repo

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -212,27 +212,6 @@ jobs:
         run: |
           docker container stop registry
           docker container rm -v registry
-      - name: push
-        uses: github-actions-x/commit@v2.9
-        if: ${{ inputs.ref == '' && always()}} # push result also on failure
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'add test report'
-          files: README.md docs/
-          name: github-ation
-          email: noreply@github.com
-      - name: send test result as PR comment
-        if: ${{ inputs.ref == '' && github.event.client_payload }}
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          script: |
-            github.rest.issues.createComment({
-              owner: 'open-component-model',
-              repo: 'ocm',
-              issue_number: ${{ env.PR_NUMBER }},
-              body: 'Integration Tests for ${{ env.SHA }} run with result: ${{ env.TEST_RESULT_STR }}!'
-              })
       - name: Post to a Slack channel
         id: slack
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The ocm integration test workflow [tries to push](https://github.com/open-component-model/ocm-integrationtest/blob/main/.github/workflows/integrationtest.yaml#L215) to the repository. However, this is [failing](https://github.com/open-component-model/ocm-integrationtest/actions/runs/24176041478/job/70557567688).

In my opinion, this push is not necessary. We get notified via GH notification as well as a post in our slack channel. This is why I want to delete this step.