### PR TITLE
chore: change runner

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -44,7 +44,7 @@ permissions:
   contents: write
 jobs:
   test-ocm:
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
Summary

  - Replace custom large_runner with ubuntu-latest GitHub-hosted runner

  Notes

  - Investigated switching to ARM runners (ubuntu-24.04-arm) but ocm-setup-action hardcodes amd64, which would break the use-release: true path
  - Sticking with ubuntu-latest (x86_64) for now until upstream ARM support is added
