### PR TITLE
chore(security): remove report upload and harden workflow

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -61,7 +61,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: false
       - name: get-pr
-        if: ${{ inputs.ref!= '' }}
+        if: ${{ inputs.ref != '' }}
         env:
           INPUT_REF: ${{ inputs.ref }}
         run: |
@@ -79,7 +79,7 @@ jobs:
           echo "SHA=${PAYLOAD_SHA}" >> $GITHUB_ENV
           echo "REF=${PAYLOAD_REF}" >> $GITHUB_ENV
       - name: get-pr
-        if: ${{ inputs.pr_number!= '' }}
+        if: ${{ inputs.pr_number != '' }}
         env:
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         run: |
@@ -98,7 +98,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: false
       - name: get ocm commit
-        if: ${{ ! inputs.github.event.client_payload }}
+        if: ${{ ! github.event.client_payload }}
         run: |
           SHA=`git -C ./ocm log -1 --format='%H'`
           echo "Checked out ocm from commit: ${SHA}"
@@ -178,7 +178,7 @@ jobs:
       - name: Python add CA
         run: |
           location=`python3 -c "import certifi; print(certifi.where());"`
-          cat ${{ github.workspace}}/certs/ociregistry.crt >> location
+          cat ${{ github.workspace}}/certs/ociregistry.crt >> "$location"
           python -c "import urllib.request; urllib.request.urlopen('https://${FDQN_NAME}')"
       - name: Install Python Libs
         run: |

--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -60,14 +60,14 @@ jobs:
           repository: open-component-model/ocm-integrationtest
           token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: false
-      - name: get-pr
+      - name: get-pr (from ref)
         if: ${{ inputs.ref != '' }}
         env:
           INPUT_REF: ${{ inputs.ref }}
         run: |
           echo "Building OCM from a ref: ${INPUT_REF}"
           echo "REF=${INPUT_REF}" >> $GITHUB_ENV
-      - name: get-pr
+      - name: get-pr (from client_payload)
         if: ${{ github.event.client_payload }}
         env:
           PAYLOAD_PR: ${{ github.event.client_payload.pr }}
@@ -78,7 +78,7 @@ jobs:
           echo "PR_NUMBER=${PAYLOAD_PR}" >> $GITHUB_ENV
           echo "SHA=${PAYLOAD_SHA}" >> $GITHUB_ENV
           echo "REF=${PAYLOAD_REF}" >> $GITHUB_ENV
-      - name: get-pr
+      - name: get-pr (from pr_number)
         if: ${{ inputs.pr_number != '' }}
         env:
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
@@ -179,7 +179,7 @@ jobs:
         run: |
           location=`python3 -c "import certifi; print(certifi.where());"`
           cat ${{ github.workspace}}/certs/ociregistry.crt >> "$location"
-          python -c "import urllib.request; urllib.request.urlopen('https://${FDQN_NAME}')"
+          python3 -c "import urllib.request; urllib.request.urlopen('https://${FDQN_NAME}')"
       - name: Install Python Libs
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -182,7 +182,7 @@ jobs:
           python3 -c "import urllib.request; urllib.request.urlopen('https://${FDQN_NAME}')"
       - name: Install Python Libs
         run: |
-          python -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Test with pytest
         run: |

--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -19,11 +19,6 @@ on:
     - cron: '0 6 * * *' # 6 AM UTC everyday for default branch
   # runs on PRs via workflow_call directly from within open-component-model/ocm
   workflow_call:
-    secrets:
-        OCMBOT_APP_ID:
-          required: true
-        OCMBOT_PRIV_KEY:
-          required: true
     inputs:
       repo:
         description: "The repo to checkout, can be used to reference other repositories"
@@ -47,18 +42,11 @@ jobs:
   test-ocm:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        with: # OCMBot
-          app_id: ${{ secrets.OCMBOT_APP_ID }}
-          private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
       - name: checkout inttest
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # hard code repo because we want to reuse it across workflows
           repository: open-component-model/ocm-integrationtest
-          token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: false
       - name: get-pr (from ref)
         if: ${{ inputs.ref != '' }}
@@ -95,7 +83,6 @@ jobs:
           repository: ${{ env.REPO }}
           ref: ${{ env.REF }}
           path: ocm
-          token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: false
       - name: get ocm commit
         if: ${{ ! github.event.client_payload }}

--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -49,44 +49,54 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with: # OCMBot
           app_id: ${{ secrets.OCMBOT_APP_ID }}
           private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
       - name: checkout inttest
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # hard code repo because we want to reuse it across workflows
           repository: open-component-model/ocm-integrationtest
           token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: false
       - name: get-pr
         if: ${{ inputs.ref!= '' }}
+        env:
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          echo "Building OCM from a ref: ${{ inputs.ref }}"
-          echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          echo "Building OCM from a ref: ${INPUT_REF}"
+          echo "REF=${INPUT_REF}" >> $GITHUB_ENV
       - name: get-pr
         if: ${{ github.event.client_payload }}
+        env:
+          PAYLOAD_PR: ${{ github.event.client_payload.pr }}
+          PAYLOAD_REF: ${{ github.event.client_payload.ref }}
+          PAYLOAD_SHA: ${{ github.event.client_payload.sha }}
         run: |
-          echo "PR was triggered with payload: pr: ${{ github.event.client_payload.pr }}, ref: ${{ github.event.client_payload.ref }}, sha: ${{ github.event.client_payload.sha }}"
-          echo "PR_NUMBER=${{ github.event.client_payload.pr }}" >> $GITHUB_ENV
-          echo "SHA=${{ github.event.client_payload.sha }}" >> $GITHUB_ENV
-          echo "REF=${{ github.event.client_payload.ref }}" >> $GITHUB_ENV
+          echo "PR was triggered with payload: pr: ${PAYLOAD_PR}, ref: ${PAYLOAD_REF}, sha: ${PAYLOAD_SHA}"
+          echo "PR_NUMBER=${PAYLOAD_PR}" >> $GITHUB_ENV
+          echo "SHA=${PAYLOAD_SHA}" >> $GITHUB_ENV
+          echo "REF=${PAYLOAD_REF}" >> $GITHUB_ENV
       - name: get-pr
         if: ${{ inputs.pr_number!= '' }}
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           echo "get-pr"
-          echo "Input was: ${{ inputs.pr_number }}"
-          REF="refs/pull/${{ inputs.pr_number }}/head"
+          echo "Input was: ${INPUT_PR_NUMBER}"
+          REF="refs/pull/${INPUT_PR_NUMBER}/head"
           echo "Building OCM from a pull request: ${REF}"
           echo "REF=${REF}" >> $GITHUB_ENV
       - name: checkout ocm
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: ${{ ! inputs.use-release }}
         with:
           repository: ${{ env.REPO }}
           ref: ${{ env.REF }}
           path: ocm
           token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: false
       - name: get ocm commit
         if: ${{ ! inputs.github.event.client_payload }}
         run: |
@@ -95,14 +105,14 @@ jobs:
           echo "SHA=${SHA}" >> $GITHUB_ENV
       - name: debug env
         run: |
-          echo "PR_NUMBER=${{ env.PR_NUMBER }}"
-          echo "SHA=${{ env.SHA }}"
-          echo "REF=${{ env.REF }}"
+          echo "PR_NUMBER=${PR_NUMBER}"
+          echo "SHA=${SHA}"
+          echo "REF=${REF}"
       - name: setup OCM
-        uses: open-component-model/ocm-setup-action@main
+        uses: open-component-model/ocm-setup-action@8c71929f38d3486e352e5d7aaf813f36accaaf43 # main
         if: ${{ inputs.use-release }}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: '${{ github.workspace }}/ocm/go.mod'
       - name: create-cert
@@ -146,7 +156,7 @@ jobs:
             -e REGISTRY_HTTP_TLS_KEY=/certs/ociregistry.key \
             registry:2.8.3
       - name: Install Crane
-        uses: imjasonh/setup-crane@v0.5
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
       - name: Build OCM
         if: ${{ ! inputs.use-release }}
         run: |
@@ -159,7 +169,7 @@ jobs:
       - name: Wait for OCI registry to become ready
         timeout-minutes: 3
         run: |
-          while ! curl https://${{ env.FDQN_NAME }}/v2
+          while ! curl "https://${FDQN_NAME}/v2"
           do
             echo "Waiting for container to become ready... still trying"
             sleep 1
@@ -169,7 +179,7 @@ jobs:
         run: |
           location=`python3 -c "import certifi; print(certifi.where());"`
           cat ${{ github.workspace}}/certs/ociregistry.crt >> location
-          python -c "import urllib.request; urllib.request.urlopen('https://${{ env.FDQN_NAME }}')"
+          python -c "import urllib.request; urllib.request.urlopen('https://${FDQN_NAME}')"
       - name: Install Python Libs
         run: |
           python -m pip install --upgrade pip
@@ -187,7 +197,6 @@ jobs:
           echo "TEST_RUN_TS=${now}" >> $GITHUB_ENV
           echo "TEST_RESULT=${res}" >> $GITHUB_ENV
           echo "OCM_VERSION=${ocm_ver}" >> $GITHUB_ENV
-          cp docs/report.html docs/report-${{ env.SHA }}.html
           if [ ${res} -eq  0 ]; then
             echo "Tests run successfully."
             echo "TEST_RESULT_STR=Success &#9989;" >> $GITHUB_ENV
@@ -221,7 +230,7 @@ jobs:
                   "text":
                     {
                       "type": "mrkdwn",
-                      "text": "Integration Test for OCM CLI ${{ job.status == 'success' && ':white_check_mark:' || ':x:' }}  <https://open-component-model.github.io/ocm-integrationtest/report-${{ env.SHA }}.html|TestReport>  <https://github.com/open-component-model/ocm-integrationtest/actions/runs/${{ github.run_id }}|Github Action>"
+                      "text": "Integration Test for OCM CLI ${{ job.status == 'success' && ':white_check_mark:' || ':x:' }}  <https://github.com/open-component-model/ocm-integrationtest/actions/runs/${{ github.run_id }}|Github Action>"
                     }
                 }
               ]

--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -41,7 +41,8 @@ env:
   REF: main
 
 permissions:
-  contents: write
+  contents: read
+
 jobs:
   test-ocm:
     runs-on: ubuntu-latest
@@ -197,16 +198,6 @@ jobs:
             echo "$now | ${ocm_ver} | &#10060; (failed)" >> README.md
           fi
           exit ${res}
-      - name: Upload Report
-        # only upload the artifact if we are not on a PR
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          if-no-files-found: error
-          overwrite: true
-          retention-days: 7
-          name: test-report
-          path: docs/report.html
       - name: stop docker registry
         if: always()
         run: |


### PR DESCRIPTION
## Summary

- Remove report upload artifact step and report link from Slack notification (no longer used)
- Downgrade workflow permissions from `contents: write` to `contents: read`
- Pin all action references to commit SHAs to prevent supply-chain attacks
- Fix template injection vulnerabilities by moving untrusted inputs (`inputs.*`, `github.event.client_payload.*`) from `run:` blocks into step-level `env:` mappings
- Add `persist-credentials: false` to checkout steps to prevent credential persistence

## Security

All findings from `zizmor` are now resolved (0 findings, previously 21 active + 8 suppressed).