### PR TITLE
fix: fix workflow when using 'use-release' and add sudo

### DIFF
--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -14,6 +14,15 @@ on:
         description: "Number of PR to test (without #, e.g.: 517)"
         required: false
 
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/integrationtest.yaml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/integrationtest.yaml'
+
   # runs regularly on main
   schedule:
     - cron: '0 6 * * *' # 6 AM UTC everyday for default branch

--- a/.github/workflows/integrationtest.yaml
+++ b/.github/workflows/integrationtest.yaml
@@ -85,7 +85,7 @@ jobs:
           path: ocm
           persist-credentials: false
       - name: get ocm commit
-        if: ${{ ! github.event.client_payload }}
+        if: ${{ ! inputs.use-release && ! github.event.client_payload }}
         run: |
           SHA=`git -C ./ocm log -1 --format='%H'`
           echo "Checked out ocm from commit: ${SHA}"
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version-file: '${{ github.workspace }}/ocm/go.mod'
+          go-version-file: '${{ github.workspace }}/${{ inputs.use-release && ''go.mod'' || ''ocm/go.mod'' }}'
       - name: create-cert
         run: |
           FDQN_NAME=`hostname --fqdn`
@@ -165,7 +165,7 @@ jobs:
       - name: Python add CA
         run: |
           location=`python3 -c "import certifi; print(certifi.where());"`
-          cat ${{ github.workspace}}/certs/ociregistry.crt >> "$location"
+          cat ${{ github.workspace}}/certs/ociregistry.crt | sudo tee -a "$location" > /dev/null
           python3 -c "import urllib.request; urllib.request.urlopen('https://${FDQN_NAME}')"
       - name: Install Python Libs
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-component-model/ocm-integrationtest
 
-go 1.23.2
+go 1.26.2


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the integration test workflow when using the `use-release` input and adds several improvements:

1. **Guard "get ocm commit" step** — Skip when `use-release` is true since the `ocm/` directory doesn't exist in that mode
2. **Conditional go-version-file** — Use the root `go.mod` when `use-release` is true (no `ocm/go.mod` available)
3. **Fix CA cert permission** — Use `sudo tee` to append to Python's certifi bundle (may not be user-writable)
4. **Add push/PR trigger** — Run the workflow when the workflow file itself is modified
5. **Bump Go version** — Update root `go.mod` from 1.23.2 to 1.26.2 to match OCM

## Which issue(s) this PR is related to

N/A